### PR TITLE
Add tone, philosophy, and meta goal to settings

### DIFF
--- a/prompt-meta.json
+++ b/prompt-meta.json
@@ -20,5 +20,6 @@
   "outputFormat": {
     "system": "string",
     "user": "string"
-  }
+  },
+  "userPromptGoal": "Craft a friendly and brief tech strategy insight. Structure the response with a light narrative tone, using a -> b -> c style, and keep it under ~200 words. Avoid bullet points unless necessary."
 }

--- a/settings-tone.json
+++ b/settings-tone.json
@@ -1,7 +1,7 @@
 {
   "voice": {
-    "tone": "Warm, intelligent, practical, and encouraging",
-    "style": "Plainspoken, not preachy. Friendly, but not overly casual. Calm and clear.",
+    "tone": "Supportive and insightful, but never verbose. Keep responses punchy and direct, without losing warmth.",
+    "style": "Conversational, friendly, and efficient. Avoid overly formal or long-winded responses.",
     "avoid": [
       "technical jargon",
       "fear-based selling",

--- a/settings-values.json
+++ b/settings-values.json
@@ -7,5 +7,6 @@
     "Respect time, budget, and energy",
     "Don't push solutions—offer them",
     "Support learning, not dependence"
-  ]
+  ],
+  "philosophy": "We meet people where they are. Good advice should be actionable and feel possible — not overwhelming or salesy."
 }


### PR DESCRIPTION
## Summary
- update tone settings with concise supportive style
- add philosophy statement to values settings
- specify new goal in prompt meta settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55fe508883248cbf375967222482