### PR TITLE
Add format guidelines

### DIFF
--- a/prompt-meta.json
+++ b/prompt-meta.json
@@ -21,5 +21,11 @@
     "system": "string",
     "user": "string"
   },
-  "userPromptGoal": "Craft a friendly and brief tech strategy insight. Structure the response with a light narrative tone, using a -> b -> c style, and keep it under ~200 words. Avoid bullet points unless necessary."
+  "userPromptGoal": "Craft a friendly and brief tech strategy insight. Structure the response with a light narrative tone, using a -> b -> c style, and keep it under ~200 words. Avoid bullet points unless necessary.",
+  "format": {
+    "length": "Responses should be 150–200 words maximum.",
+    "structure": "Narrative with light structure. Prefer cause-and-effect logic to disjointed lists.",
+    "endings": "Avoid closing statements or sign-offs unless contextually appropriate.",
+    "greeting": "Skip a greeting at the start unless context calls for it."
+  }
 }


### PR DESCRIPTION
## Summary
- remove `settings-format.json`
- revert worker to load only existing settings files
- store response format rules under `format` in `prompt-meta.json`
- add rule to skip greetings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a84e46c832483f073d73f0a0147